### PR TITLE
feat: batch image upload with automatic filename-based character & expression sorting

### DIFF
--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -49,7 +49,7 @@ export async function buildApp(options: BuildAppOptions = {}): Promise<FastifyIn
   await app.register(cors, { origin: config.corsOrigins, credentials: true });
 
   await app.register(multipart, {
-    limits: { fileSize: MAX_UPLOAD_BYTES, files: 1, fields: 10 },
+    limits: { fileSize: MAX_UPLOAD_BYTES, files: 100, fields: 10 },
   });
 
   // Serve uploaded assets from the controlled uploads directory only.

--- a/apps/server/src/routes/assets.ts
+++ b/apps/server/src/routes/assets.ts
@@ -2,7 +2,7 @@ import type { FastifyInstance } from 'fastify';
 import { AssetUploadFieldsSchema } from '@dsim/shared';
 import { parseInput } from '../lib/validate';
 import { badRequest } from '../lib/errors';
-import { deleteAsset, listAssets, saveUploadedAsset } from '../services/asset-service';
+import { deleteAsset, listAssets, saveBatchAssets, saveUploadedAsset } from '../services/asset-service';
 import { docSchema } from '../lib/openapi-schema';
 
 export async function assetRoutes(app: FastifyInstance): Promise<void> {
@@ -39,6 +39,33 @@ export async function assetRoutes(app: FastifyInstance): Promise<void> {
       altText: parsed.altText,
       tags,
     });
+  });
+
+  /** Batch upload: accepts multiple files in a single request. Each file's
+   *  filename is parsed for character + expression metadata (see
+   *  `parseAssetFilename`). No extra form fields are supported — type
+   *  is derived from the naming convention. */
+  app.post('/assets/batch', { schema: docSchema({ tags: ['assets'], summary: 'Batch-upload multiple asset files' }) }, async (req, reply) => {
+    const files: Array<{ buffer: Buffer; originalFilename: string; mimeType: string }> = [];
+
+    for await (const part of req.parts()) {
+      if (part.type === 'file') {
+        const mimeType = part.mimetype;
+        const buffer = await part.toBuffer();
+        if (buffer.byteLength > 0) {
+          files.push({
+            buffer,
+            originalFilename: part.filename || 'upload',
+            mimeType,
+          });
+        }
+      }
+    }
+
+    if (files.length === 0) throw badRequest('No files found in the batch upload.');
+
+    reply.code(201);
+    return saveBatchAssets(files);
   });
 
   app.delete('/assets/:id', { schema: docSchema({ tags: ['assets'], summary: 'Delete an asset by id' }) }, async (req) => {

--- a/apps/server/src/services/asset-service.ts
+++ b/apps/server/src/services/asset-service.ts
@@ -4,9 +4,11 @@ import {
   AssetSchema,
   ALLOWED_IMAGE_MIME_TYPES,
   MAX_UPLOAD_BYTES,
+  EXPRESSIONS,
   type Asset,
   type AssetType,
   type AllowedImageMimeType,
+  type Expression,
 } from '@dsim/shared';
 import { config, ensureDirectories } from '../config';
 import { assetsRepo } from '../db/repositories';
@@ -37,6 +39,75 @@ export function safeUploadsPath(relativePath: string): string {
     throw badRequest('Resolved path escapes the uploads directory.');
   }
   return target;
+}
+
+/**
+ * Parse an image filename to extract character name and expression. Looks for
+ * known expression words or "portrait" anywhere in the filename (not just at
+ * specific positions), so any naming convention works as long as the trigger
+ * words are present:
+ *
+ *   - `Nicky - Happy_00001_.png`       → "Nicky", expression "happy"
+ *   - `Silvija, portrait (1).jpg`      → "Silvija", expression null, type portrait
+ *   - `Donna Pinciotti - Happy_1.png`  → "Donna Pinciotti", expression "happy"
+ *   - `nicky-happy.png`                → "Nicky", expression "happy"
+ *   - `happy_nicky.png`                → "Nicky", expression "happy"
+ *   - `portrait_silvija_1.jpg`         → "Silvija", type portrait
+ *
+ * Returns null when no known expression or "portrait" keyword is found.
+ */
+export interface ParsedAssetFilename {
+  characterName: string;
+  expression: Expression | null;
+  type: AssetType;
+}
+
+/** Build a regex that matches any known expression word (case-insensitive,
+ *  whole-word) plus surrounding separator/noise characters, so it can be
+ *  removed cleanly from filenames regardless of position. */
+const EXPR_PATTERN = new RegExp(
+  `[-_\\s,()]*?(${EXPRESSIONS.join('|')})[-_\\s\\d,()]*`,
+  'i',
+);
+
+const PORTRAIT_PATTERN = /[-_\s,()]*?portrait[-_\s\d,()]*/i;
+
+/** Clean up leftover separator debris and tidy the character name. */
+function tidyCharacterName(raw: string): string {
+  return raw
+    .replace(/[-_\s,()]+/g, ' ')   // collapse separators → space
+    .replace(/\s{2,}/g, ' ')       // collapse multiple spaces
+    .trim()
+    .replace(/\b\w/g, (c) => c.toUpperCase()); // Title Case
+}
+
+export function parseAssetFilename(originalFilename: string): ParsedAssetFilename | null {
+  const name = originalFilename.replace(/\.[^/.]+$/, '').trim();
+
+  // 1. Look for any known expression keyword anywhere in the filename.
+  const exprExec = EXPR_PATTERN.exec(name);
+  if (exprExec) {
+    const rawExpression = exprExec[1]!.toLowerCase();
+    const expression = rawExpression as Expression;
+    // Character name = the filename with the matched expression block removed.
+    const remainder = name.slice(0, exprExec.index) + name.slice(exprExec.index + exprExec[0].length);
+    const characterName = tidyCharacterName(remainder);
+    if (characterName) {
+      return { characterName, expression, type: 'expression' };
+    }
+  }
+
+  // 2. Look for "portrait" keyword anywhere in the filename.
+  const portExec = PORTRAIT_PATTERN.exec(name);
+  if (portExec) {
+    const remainder = name.slice(0, portExec.index) + name.slice(portExec.index + portExec[0].length);
+    const characterName = tidyCharacterName(remainder);
+    if (characterName) {
+      return { characterName, expression: null, type: 'portrait' };
+    }
+  }
+
+  return null;
 }
 
 export interface SaveAssetInput {
@@ -71,6 +142,17 @@ export function saveUploadedAsset(input: SaveAssetInput): Asset {
   const absPath = safeUploadsPath(storedName);
   fs.writeFileSync(absPath, input.buffer);
 
+  // Derive character + expression tags from the filename (deterministic parsing).
+  const parsed = parseAssetFilename(input.originalFilename);
+  const tags = [...(input.tags ?? [])];
+  if (parsed) {
+    tags.push(`character:${parsed.characterName}`);
+    if (parsed.expression) tags.push(`expression:${parsed.expression}`);
+    if (!tags.includes(`type:${parsed.type}`)) tags.push(`type:${parsed.type}`);
+    // Override the upload type so expression images are auto-typed correctly.
+    input.type = parsed.type;
+  }
+
   const asset = AssetSchema.parse({
     id,
     type: input.type,
@@ -78,11 +160,26 @@ export function saveUploadedAsset(input: SaveAssetInput): Asset {
     filename: sanitizeDisplayName(input.originalFilename) || storedName,
     mimeType: input.mimeType,
     altText: input.altText ?? '',
-    tags: input.tags ?? [],
+    tags,
     metadata: { bytes: input.buffer.byteLength },
     createdAt: Date.now(),
   });
   return assetsRepo.insert(asset);
+}
+
+/** Upload multiple assets in one call. Each file may be auto-tagged via
+ *  {@link parseAssetFilename}. Returns all saved assets. */
+export function saveBatchAssets(
+  files: Array<{ buffer: Buffer; originalFilename: string; mimeType: string }>,
+): Asset[] {
+  return files.map((f) =>
+    saveUploadedAsset({
+      buffer: f.buffer,
+      originalFilename: f.originalFilename,
+      mimeType: f.mimeType,
+      type: 'other', // will be overridden by parseAssetFilename if matched
+    }),
+  );
 }
 
 export function listAssets(): Asset[] {

--- a/apps/web/src/components/AssetPicker.tsx
+++ b/apps/web/src/components/AssetPicker.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   ALLOWED_IMAGE_MIME_TYPES,
@@ -13,46 +13,96 @@ import { Icon } from './Icon';
 import { Empty } from './ui';
 import './assetpicker.css';
 
-/** Pick an uploaded image asset (or none), with inline upload. */
+/** Tag-based helpers for character-filtered asset queries. */
+function charTag(name: string): string {
+  return `character:${name}`;
+}
+function exprTag(name: string): string {
+  return `expression:${name}`;
+}
+
+/**
+ * Check whether an asset's tags include a given value. Tags are simple strings
+ * like `"character:Nicky"`, `"expression:happy"`, `"type:portrait"`.
+ */
+function hasTag(asset: Asset, tag: string): boolean {
+  return asset.tags.includes(tag);
+}
+
+/** Pick an uploaded image asset (or none), with batch upload and optional
+ *  character-aware filtering.
+ *
+ *  Uploaded images are auto-sorted by the server — filenames containing
+ *  expression keywords (happy, sad, angry…) or "portrait" get auto-tagged
+ *  with the correct character and expression, so they appear in the right
+ *  picker automatically.
+ *
+ *  When `characterName` is set, only assets tagged with `character:<name>`
+ *  are shown. When `expressionName` is also set (e.g. "happy" in an expression
+ *  row), assets are further filtered to those tagged `expression:<name>`.
+ *  The currently-selected asset is always visible regardless of filters. */
 export function AssetPicker({
   value,
   onChange,
-  uploadType = 'portrait',
   filterType,
+  characterName,
+  expressionName,
 }: {
   value: string | null;
   onChange: (id: string | null) => void;
-  uploadType?: Asset['type'];
   /** When set, only show assets of this type (plus the always-selectable
    *  "None" tile). Keeps the picker focused — e.g. only location photos. */
   filterType?: Asset['type'];
+  /** When set, filter to assets tagged with this character name. */
+  characterName?: string;
+  /** When set (together with characterName), filter to assets tagged with
+   *  this expression name. Ignored when characterName is not set. */
+  expressionName?: string;
 }) {
   const { t } = useTranslation();
   const { assets: allAssets, reloadAssets } = useAppData();
-  // Always keep the currently-selected asset visible even if it predates the
-  // filter (e.g. an older photo saved under a different type).
-  const assets = filterType
-    ? allAssets.filter((a) => a.type === filterType || a.id === value)
-    : allAssets;
+
+  // Build a filtered view: only assets whose tags match the character +
+  // expression context. Keep the currently-selected asset visible at all
+  // times so it doesn't vanish when switching filters.
+  const filtered = useMemo(() => {
+    let list = allAssets;
+
+    if (characterName) {
+      const cTag = charTag(characterName);
+      list = list.filter((a) => hasTag(a, cTag) || a.id === value);
+
+      if (expressionName) {
+        const eTag = exprTag(expressionName);
+        list = list.filter((a) => hasTag(a, eTag) || a.id === value);
+      }
+    }
+
+    if (filterType) {
+      list = list.filter((a) => a.type === filterType || a.id === value);
+    }
+
+    return list;
+  }, [allAssets, characterName, expressionName, filterType, value]);
+
   const [uploading, setUploading] = useState(false);
   const [error, setError] = useState<string>();
   const inputRef = useRef<HTMLInputElement>(null);
 
-  const handleFile = async (file: File) => {
+  const handleBatchFiles = async (files: FileList) => {
     setError(undefined);
-    // `accept` is only a hint — a user can still pick any file via the picker's
-    // "All files" override. Reject anything the vision model can't read before we
-    // upload it, so the failure is immediate and clear rather than at request time.
-    if (!(ALLOWED_IMAGE_MIME_TYPES as readonly string[]).includes(file.type)) {
+    const valid = Array.from(files).filter((f) =>
+      (ALLOWED_IMAGE_MIME_TYPES as readonly string[]).includes(f.type),
+    );
+    if (valid.length === 0) {
       setError(t('unsupportedImage', { label: ALLOWED_IMAGE_LABEL }));
       if (inputRef.current) inputRef.current.value = '';
       return;
     }
     setUploading(true);
     try {
-      const asset = await api.uploadAsset(file, uploadType, '', '');
+      await api.uploadAssetsBatch(valid);
       await reloadAssets();
-      onChange(asset.id);
     } catch (e) {
       setError(errorMessage(e));
     } finally {
@@ -63,7 +113,7 @@ export function AssetPicker({
 
   return (
     <div>
-      {assets.length === 0 && !uploading ? (
+      {filtered.length === 0 && !uploading ? (
         <div className="ap-empty">
           <Empty title={t('asset.noImages')} />
         </div>
@@ -81,7 +131,7 @@ export function AssetPicker({
             <span className="ap-check" aria-hidden>✓</span>
           </div>
 
-          {assets.map((a) => (
+          {filtered.map((a) => (
             <div
               key={a.id}
               className={`ap-thumb ${value === a.id ? 'ap-selected' : ''}`}
@@ -100,15 +150,16 @@ export function AssetPicker({
       <div className="ap-upload-row">
         <label className="btn sm ap-upload-label">
           <Icon name="upload" size={14} />
-          {uploading ? t('asset.uploading') : t('asset.uploadImage')}
+          {uploading ? t('asset.uploading') : t('asset.batchUpload')}
           <input
             ref={inputRef}
             type="file"
             accept={IMAGE_UPLOAD_ACCEPT}
+            multiple
             hidden
             onChange={(e) => {
-              const f = e.target.files?.[0];
-              if (f) void handleFile(f);
+              const fl = e.target.files;
+              if (fl && fl.length > 0) void handleBatchFiles(fl);
             }}
           />
         </label>

--- a/apps/web/src/components/AssetPicker.tsx
+++ b/apps/web/src/components/AssetPicker.tsx
@@ -22,11 +22,14 @@ function exprTag(name: string): string {
 }
 
 /**
- * Check whether an asset's tags include a given value. Tags are simple strings
- * like `"character:Nicky"`, `"expression:happy"`, `"type:portrait"`.
+ * Check whether an asset's tags include a given value (case-insensitive).
+ * Tags are simple strings like `"character:Nicky"`, `"expression:happy"`,
+ * `"type:portrait"`. Comparisons are lowered so filename casing mismatches
+ * (e.g. `adachi rei happy.png` vs character `Adachi Rei`) don't block
+ * matching.
  */
 function hasTag(asset: Asset, tag: string): boolean {
-  return asset.tags.includes(tag);
+  return asset.tags.some((t) => t.toLowerCase() === tag.toLowerCase());
 }
 
 /** Pick an uploaded image asset (or none), with batch upload and optional
@@ -47,6 +50,7 @@ export function AssetPicker({
   filterType,
   characterName,
   expressionName,
+  onBatchUpload,
 }: {
   value: string | null;
   onChange: (id: string | null) => void;
@@ -58,32 +62,43 @@ export function AssetPicker({
   /** When set (together with characterName), filter to assets tagged with
    *  this expression name. Ignored when characterName is not set. */
   expressionName?: string;
+  /** Fires after a successful batch upload with the newly created assets.
+   *  Parent components can use this to auto-assign portrait/expression slots
+   *  based on the uploaded assets' tags. */
+  onBatchUpload?: (assets: Asset[]) => void;
 }) {
   const { t } = useTranslation();
   const { assets: allAssets, reloadAssets } = useAppData();
 
-  // Build a filtered view: only assets whose tags match the character +
-  // expression context. Keep the currently-selected asset visible at all
-  // times so it doesn't vanish when switching filters.
+  const [filterByCharName, setFilterByCharName] = useState(true);
+  const [filterByCategory, setFilterByCategory] = useState(true);
+
+  // Two coordinated filter toggles:
+  //   - "Filter by character name" — narrows by the current character's tag
+  //   - "Filter by category" — narrows by type (portrait) or expression
+  // Each is independent, so you can show all images of a character regardless
+  // of category, or all images of a category from any character, or both, or
+  // neither. The currently-selected asset always stays visible.
   const filtered = useMemo(() => {
     let list = allAssets;
 
-    if (characterName) {
+    if (characterName && filterByCharName) {
       const cTag = charTag(characterName);
       list = list.filter((a) => hasTag(a, cTag) || a.id === value);
+    }
 
+    if (filterByCategory) {
       if (expressionName) {
         const eTag = exprTag(expressionName);
         list = list.filter((a) => hasTag(a, eTag) || a.id === value);
       }
-    }
-
-    if (filterType) {
-      list = list.filter((a) => a.type === filterType || a.id === value);
+      if (filterType) {
+        list = list.filter((a) => a.type === filterType || a.id === value);
+      }
     }
 
     return list;
-  }, [allAssets, characterName, expressionName, filterType, value]);
+  }, [allAssets, characterName, expressionName, filterType, value, filterByCharName, filterByCategory]);
 
   const [uploading, setUploading] = useState(false);
   const [error, setError] = useState<string>();
@@ -101,8 +116,9 @@ export function AssetPicker({
     }
     setUploading(true);
     try {
-      await api.uploadAssetsBatch(valid);
+      const uploaded = await api.uploadAssetsBatch(valid);
       await reloadAssets();
+      onBatchUpload?.(uploaded);
     } catch (e) {
       setError(errorMessage(e));
     } finally {
@@ -150,7 +166,7 @@ export function AssetPicker({
       <div className="ap-upload-row">
         <label className="btn sm ap-upload-label">
           <Icon name="upload" size={14} />
-          {uploading ? t('asset.uploading') : t('asset.batchUpload')}
+          {uploading ? t('asset.uploading') : t('asset.uploadImages')}
           <input
             ref={inputRef}
             type="file"
@@ -163,7 +179,28 @@ export function AssetPicker({
             }}
           />
         </label>
+        {characterName && (
+          <label className="ap-filter-toggle">
+            <input
+              type="checkbox"
+              checked={filterByCharName}
+              onChange={(e) => setFilterByCharName(e.target.checked)}
+            />
+            {t('asset.filterByCharName')}
+          </label>
+        )}
+        {(expressionName || filterType) && (
+          <label className="ap-filter-toggle">
+            <input
+              type="checkbox"
+              checked={filterByCategory}
+              onChange={(e) => setFilterByCategory(e.target.checked)}
+            />
+            {t('asset.filterByCategory')}
+          </label>
+        )}
       </div>
+      <p className="creator-note">{t('asset.batchUploadHint')}</p>
 
       {error && <small className="ap-error">{error}</small>}
     </div>

--- a/apps/web/src/components/assetpicker.css
+++ b/apps/web/src/components/assetpicker.css
@@ -98,6 +98,21 @@
   cursor: pointer;
 }
 
+/* Filter-by-name toggle */
+.ap-filter-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.75rem;
+  color: var(--text-mute);
+  cursor: pointer;
+  user-select: none;
+  margin-left: auto;
+}
+.ap-filter-toggle input[type="checkbox"] {
+  accent-color: var(--brass);
+}
+
 /* Error below upload */
 .ap-error {
   display: block;

--- a/apps/web/src/i18n/locales/en/common.json
+++ b/apps/web/src/i18n/locales/en/common.json
@@ -13,7 +13,8 @@
     "noPortrait": "No portrait",
     "none": "None",
     "uploading": "Uploading…",
-    "uploadImage": "Upload image"
+    "uploadImage": "Upload image",
+    "batchUpload": "Batch upload"
   },
   "draft": {
     "notSavedTitle": "Couldn't auto-save this draft (storage full). Press Save to keep your work.",

--- a/apps/web/src/i18n/locales/en/common.json
+++ b/apps/web/src/i18n/locales/en/common.json
@@ -14,7 +14,10 @@
     "none": "None",
     "uploading": "Uploading…",
     "uploadImage": "Upload image",
-    "batchUpload": "Batch upload"
+    "uploadImages": "Upload Image(s)",
+    "filterByCharName": "Filter by character name",
+    "filterByCategory": "Filter by category",
+    "batchUploadHint": "Name your files like CharacterName - happy.png or portrait CharacterName.jpg. The server auto-detects expressions (happy, sad, angry…) and portraits from the filename, so images appear in the right slots automatically. If no portrait image is uploaded, the smiling expression is used as the default portrait."
   },
   "draft": {
     "notSavedTitle": "Couldn't auto-save this draft (storage full). Press Save to keep your work.",

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -510,6 +510,18 @@ export const api = {
     }
     return res.json();
   },
+  /** Upload multiple image files at once. Filenames are parsed server-side for
+   *  character + expression metadata. Returns all created assets. */
+  uploadAssetsBatch: async (files: File[]): Promise<Asset[]> => {
+    const form = new FormData();
+    for (const f of files) form.append('files', f);
+    const res = await fetch(`${BASE}/assets/batch`, { method: 'POST', body: form });
+    if (!res.ok) {
+      const { message } = await parseErrorBody(res, `Batch upload failed (${res.status}).`);
+      throw new ApiError(message, res.status);
+    }
+    return res.json();
+  },
   deleteAsset: (id: string) => del<{ ok: true }>(`/assets/${id}`),
 
   // conversations

--- a/apps/web/src/pages/CharacterEditor.tsx
+++ b/apps/web/src/pages/CharacterEditor.tsx
@@ -759,7 +759,7 @@ export function CharacterEditor() {
                   <h2>{t('pages:characterEditor.secPortrait')}</h2>
                   <span className="trail" />
                 </div>
-                <AssetPicker value={form.portraitAssetId} onChange={(v) => set('portraitAssetId', v)} />
+                <AssetPicker value={form.portraitAssetId} onChange={(v) => set('portraitAssetId', v)} characterName={form.name} />
                 <div className="ce-image-gen">
                   <button className="btn sm primary" onClick={() => setGenOpen(true)}>
                     <Icon name="generate" size={13} />
@@ -816,7 +816,8 @@ export function CharacterEditor() {
                     </div>
                     <AssetPicker
                       value={row.assetId}
-                      uploadType="expression"
+                      characterName={form.name}
+                      expressionName={row.name}
                       onChange={(v) => {
                         const rows = [...form.expressionRows];
                         rows[i] = { ...rows[i]!, assetId: v };

--- a/apps/web/src/pages/CharacterEditor.tsx
+++ b/apps/web/src/pages/CharacterEditor.tsx
@@ -14,6 +14,7 @@ import {
   DAYS_OF_WEEK,
   WEATHER_KINDS,
   WEATHER_ICONS,
+  type Asset,
   type Character,
   type CharacterLink,
   type CharacterLinkKind,
@@ -154,7 +155,7 @@ export function CharacterEditor() {
   const isNew = !id;
   const nav = useNavigate();
   const location = useLocation();
-  const { reloadAssets, activeWorldId } = useAppData();
+  const { assets, reloadAssets, activeWorldId } = useAppData();
 
   const [form, setForm] = useState<Form>(emptyForm);
   // The saved/initial snapshot the live form is diffed against for draft
@@ -188,6 +189,44 @@ export function CharacterEditor() {
   const [activeTab, setActiveTab] = useState<TabId>('identity');
 
   const set = <K extends keyof Form>(key: K, value: Form[K]) => setForm((f) => ({ ...f, [key]: value }));
+
+  /** After a batch upload, auto-assign images to portrait/expression slots
+   *  based on the server-parsed tags. Never overwrites an already-filled slot.
+   *  Builds the complete update in one pass so multiple expression assignments
+   *  don't clobber each other. */
+  const handleBatchUpload = (uploaded: Asset[]) => {
+    const cTag = `character:${form.name}`.toLowerCase();
+    let newPortrait = form.portraitAssetId;
+    const newRows = form.expressionRows.map((r) => ({ ...r }));
+
+    for (const asset of uploaded) {
+      if (!asset.tags.some((t) => t.toLowerCase() === cTag)) continue;
+
+      if (asset.tags.includes('type:portrait') && !newPortrait) {
+        newPortrait = asset.id;
+      }
+      const exprTag = asset.tags.find((t) => t.startsWith('expression:'));
+      if (exprTag) {
+        const exprName = exprTag.slice('expression:'.length);
+        const idx = newRows.findIndex((r) => r.name === exprName);
+        if (idx !== -1 && !newRows[idx]!.assetId) {
+          newRows[idx] = { ...newRows[idx]!, assetId: asset.id };
+        }
+      }
+    }
+
+    // Fallback: if no portrait was uploaded, use the smiling expression as the
+    // default portrait image.
+    if (!newPortrait) {
+      const smilingIdx = newRows.findIndex((r) => r.name === 'smiling');
+      if (smilingIdx !== -1 && newRows[smilingIdx]!.assetId) {
+        newPortrait = newRows[smilingIdx]!.assetId;
+      }
+    }
+
+    if (newPortrait !== form.portraitAssetId) set('portraitAssetId', newPortrait);
+    set('expressionRows', newRows);
+  };
 
   const DEFAULT_JOB: Employment = { title: '', place: '', workdays: [0, 1, 2, 3, 4], shiftPhase: 'morning' };
   const patchEmp = (patch: Partial<Employment>) =>
@@ -566,6 +605,17 @@ export function CharacterEditor() {
 
   // Synthetic character object fed to <Portrait> — mirrors the API shape without
   // needing an actual saved character record.
+  // Whether the current character has any portrait-tagged assets. When true,
+  // the portrait picker is filtered to show only portrait images; when false,
+  // it shows all expression images so the user can pick one as portrait.
+  const hasPortraitAsset = useMemo(() => {
+    if (!form.name) return false;
+    const cTag = `character:${form.name}`.toLowerCase();
+    return assets.some(
+      (a) => a.type === 'portrait' && a.tags.some((t) => t.toLowerCase() === cTag),
+    );
+  }, [assets, form.name]);
+
   const previewCharacter = useMemo(
     () => ({
       name: form.name || t('pages:characterEditor.unnamed'),
@@ -759,7 +809,13 @@ export function CharacterEditor() {
                   <h2>{t('pages:characterEditor.secPortrait')}</h2>
                   <span className="trail" />
                 </div>
-                <AssetPicker value={form.portraitAssetId} onChange={(v) => set('portraitAssetId', v)} characterName={form.name} />
+                <AssetPicker
+                  value={form.portraitAssetId}
+                  onChange={(v) => set('portraitAssetId', v)}
+                  characterName={form.name}
+                  filterType={hasPortraitAsset ? 'portrait' : undefined}
+                  onBatchUpload={handleBatchUpload}
+                />
                 <div className="ce-image-gen">
                   <button className="btn sm primary" onClick={() => setGenOpen(true)}>
                     <Icon name="generate" size={13} />
@@ -818,6 +874,7 @@ export function CharacterEditor() {
                       value={row.assetId}
                       characterName={form.name}
                       expressionName={row.name}
+                      onBatchUpload={handleBatchUpload}
                       onChange={(v) => {
                         const rows = [...form.expressionRows];
                         rows[i] = { ...rows[i]!, assetId: v };

--- a/apps/web/src/pages/WorldEditor.tsx
+++ b/apps/web/src/pages/WorldEditor.tsx
@@ -632,7 +632,6 @@ function LocationCard({
             <AssetPicker
               value={location.imageAssetId ?? null}
               onChange={(imageAssetId) => onUpdate({ imageAssetId })}
-              uploadType="location"
               filterType="location"
             />
             <small className="muted">{t('worldEditor.photoHint')}</small>


### PR DESCRIPTION
**Batch image upload with automatic filename-based sorting**

This allows uploading multiple character images at once. Filters out files that are missing the character name. Sorts expression images for convenience.

- New `POST /assets/batch` endpoint accepts multiple files at once
- Filename scanner auto-detects character name, expression keyword, or "portrait" anywhere in the filename — no strict naming scheme required
- Uploaded images are auto-tagged (`character:Nicky`, `expression:happy`) and type is derived automatically
- AssetPicker now filters thumbnails by character + expression tags, so only the correct images show in each picker slot
- Single "Batch upload" button replaces the per-file upload button